### PR TITLE
Handle file-like objects with integer name attribute

### DIFF
--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -312,10 +312,11 @@ class Entry(object):
             call_and_check(_libarchive.archive_read_next_header2, archive._a, archive._a, e)
             mode = _libarchive.archive_entry_filetype(e)
             mode |= _libarchive.archive_entry_perm(e)
+
             if PY3:
-                pathname=_libarchive.archive_entry_pathname(e)
+                pathname = _libarchive.archive_entry_pathname(e)
             else:
-                pathname=_libarchive.archive_entry_pathname(e).decode(encoding),
+                pathname = _libarchive.archive_entry_pathname(e).decode(encoding)
 
             entry = cls(
                 pathname=pathname,
@@ -628,11 +629,7 @@ class SeekableArchive(Archive):
     def getentry(self, pathname):
         '''Take a name or entry object and returns an entry object.'''
         for entry in self:
-            if PY3:
-                entry_pathname = entry.pathname
-            if not PY3:
-                entry_pathname = entry.pathname[0]
-            if entry_pathname == pathname:
+            if entry.pathname == pathname:
                 return entry
         raise KeyError(pathname)
 

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -117,7 +117,10 @@ def get_func(name, items, index):
 
 
 def guess_format(filename):
-    filename, ext = os.path.splitext(filename)
+    if isinstance(filename, int):
+        filename = ext = ''
+    else:
+        filename, ext = os.path.splitext(filename)
     filter = FILTER_EXTENSIONS.get(ext)
     if filter:
         filename, ext = os.path.splitext(filename)

--- a/tests.py
+++ b/tests.py
@@ -150,10 +150,7 @@ class TestZipRead(unittest.TestCase):
         z = ZipFile(self.f, 'r')
         names = []
         for e in z:
-            if PY3:
-                names.append(e.filename)
-            else:
-                names.append(e.filename[0])
+            names.append(e.filename)
         self.assertEqual(names, FILENAMES, 'File names differ in archive.')
 
     #~ def test_non_ascii(self):

--- a/tests.py
+++ b/tests.py
@@ -33,7 +33,7 @@ from libarchive.zip import is_zipfile, ZipFile, ZipEntry
 
 PY3 = sys.version_info[0] == 3
 
-TMPDIR = tempfile.mkdtemp()
+TMPDIR = tempfile.mkdtemp(suffix='.python-libarchive')
 ZIPCMD = '/usr/bin/zip'
 ZIPFILE = 'test.zip'
 ZIPPATH = os.path.join(TMPDIR, ZIPFILE)

--- a/tests.py
+++ b/tests.py
@@ -26,7 +26,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os, unittest, tempfile, random, string, subprocess, sys
+import os, unittest, tempfile, random, string, sys
+import zipfile
 
 from libarchive import is_archive_name, is_archive
 from libarchive.zip import is_zipfile, ZipFile, ZipEntry
@@ -34,7 +35,6 @@ from libarchive.zip import is_zipfile, ZipFile, ZipEntry
 PY3 = sys.version_info[0] == 3
 
 TMPDIR = tempfile.mkdtemp(suffix='.python-libarchive')
-ZIPCMD = '/usr/bin/zip'
 ZIPFILE = 'test.zip'
 ZIPPATH = os.path.join(TMPDIR, ZIPFILE)
 
@@ -54,13 +54,10 @@ def make_temp_files():
 
 
 def make_temp_archive():
-    if not os.access(ZIPCMD, os.X_OK):
-        raise AssertionError('Cannot execute %s.' % ZIPCMD)
-    cmd = [ZIPCMD, ZIPFILE]
     make_temp_files()
-    cmd.extend(FILENAMES)
-    os.chdir(TMPDIR)
-    subprocess.call(cmd, stdout=subprocess.PIPE)
+    with zipfile.ZipFile(ZIPPATH, mode="w") as z:
+        for name in FILENAMES:
+            z.write(os.path.join(TMPDIR, name), arcname=name)
 
 
 class TestIsArchiveName(unittest.TestCase):


### PR DESCRIPTION
While working with streaming output from `rpmcpio` via `subprocess.Popen.stdout` and the high-level libarchive interface, I found that I couldn't get past an exception from `guess_format()`:
```
File "/path/to/venv/lib/python3.6/site-packages/libarchive/__init__.py", line 419, in __init__
    filter = guess_format(self.filename)[1]
  File "/path/to/venv/lib/python3.6/site-packages/libarchive/__init__.py", line 120, in guess_format
    filename, ext = os.path.splitext(filename)
  File "/usr/lib/python3.6/posixpath.py", line 122, in splitext
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not int
```

I tried setting `Archive(p.stdout, format='cpio')`, but since `filter` was `None`, I couldn't get past `guess_format()`.

I found that when `io.BufferedReader` (and others) are init-ed based on a file descriptor, their name attribute will be an integer. These objects can be handled by trapping `TypeError` in `guess_format()` and setting sane values (empty strings).

I'd considered adding an explicit `'none'` filter to the `FILTERS` dictionary to differentiate it from an undefined keyword argument, but I obviously passed on that.