### PR TITLE
readpath: fix getting basedir

### DIFF
--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -521,8 +521,8 @@ class Archive(object):
         '''Write current archive entry contents to file. f can be a file-like object or
         a path.'''
         if isinstance(f, basestring):
-            basedir = os.path.basename(f)
-            if not os.path.exists(basedir):
+            basedir = os.path.dirname(f)
+            if basedir and not os.path.exists(basedir):
                 os.makedirs(basedir)
             f = file(f, 'w')
         return _libarchive.archive_read_data_into_fd(self._a, f.fileno())


### PR DESCRIPTION
I assume that was the originally intended behaviour.
This way it creates directory to which archive's entry will be extracted.
Otherwise it will just create empty files that later remain unused.

It's pretty self explanatory but here's an example:
```python
❯ ls
archive.cpio  output
❯ cpio -it < archive.cpio 
postinstall.sh
sw-description
uImage-kernel-5.1.7-dtb-imx6q-dss11e.bin
8428 blocks
❯ python3.8
Python 3.8.3 (default, May 15 2020, 00:00:00) 
[GCC 10.1.1 20200507 (Red Hat 10.1.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os, libarchive
>>> with libarchive.Archive("archive.cpio", "r", format="cpio") as archive:
...     for entry in archive:
...             archive.readpath(os.path.join("./output/", entry.pathname))
... 
0
0
0
>>> 
❯ ls # as visible here: additional directory was created for each entry,
# extraction is fine but superfluous directories are there
archive.cpio  postinstall.sh  uImage-kernel-5.1.7-dtb-imx6q-dss11e.bin
output        sw-description
```