### PR TITLE
Remove unused environment variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,8 +19,6 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build the library
-      env:
-        PYVER: ${{ matrix.version }}
       run: python3 setup.py sdist
 
     - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Closes #28 

This environmental variable is not needed because this workflow is not actually building anything